### PR TITLE
Feat : /channel/:channelId에 유저 입장시 채팅창에 서버메시지 띄우기 구현

### DIFF
--- a/src/app/channel/_components/SocketConnector.tsx
+++ b/src/app/channel/_components/SocketConnector.tsx
@@ -33,6 +33,12 @@ const SocketConnector = ({ channelId }: Props) => {
         case 'USER_CHAT':
           setStore({ type: 'SET_CHATTING', payload: body.data });
           break;
+        case 'USER_JOIN':
+          setStore({ type: 'SET_JOIN', payload: body.data });
+          break;
+        case 'USER_LEAVE':
+          setStore({ type: 'SET_LEAVE', payload: body.data });
+          break;
         case 'PLAYLIST_ADD':
           setStore({ type: 'SET_PLAYLIST', payload: JSON.parse(body.data) });
           break;

--- a/src/app/channel/_components/chatting/ChatHeader.tsx
+++ b/src/app/channel/_components/chatting/ChatHeader.tsx
@@ -1,9 +1,8 @@
 import { useState } from 'react';
 
-import Image from 'next/image';
-
 import Tooltip from '@/components/Tooltip';
 import { useSocketStore } from '@/stores/useSocketStore';
+import Image from 'next/image';
 
 interface ChatHeaderProps {
   isFold: boolean;
@@ -19,12 +18,12 @@ export default function ChatHeader({ isFold, setIsFold }: ChatHeaderProps) {
     <header
       className={`flex h-[67px] w-full items-center justify-between bg-neutral-600 px-0 desktop:h-[90px] desktop:px-8 ${isFold && 'desktop:ml-[-10px] desktop:w-[88px]'}`}
     >
-      <div className="ml-[-10px] flex items-center gap-2.5">
+      <div className="flex items-center gap-2.5">
         <button
           onClick={() => isFold && setIsFold(false)}
           onMouseEnter={() => setShowTooltip(true)}
           onMouseLeave={() => setShowTooltip(false)}
-          className="relative flex size-[42px] shrink-0 items-center justify-center rounded hover:bg-transparent-white-10 desktop:size-[44px]"
+          className={`relative ml-[-10px] flex size-[42px] shrink-0 items-center justify-center rounded hover:bg-transparent-white-10 desktop:size-[44px] ${isFold && 'desktop:ml-0'}`}
         >
           <div className="relative size-[22px] desktop:size-[24px]">
             <Image src="/chat-two-bubble.svg" alt="채팅 아이콘" fill sizes="30vw" />

--- a/src/app/channel/_components/chatting/ChatList.tsx
+++ b/src/app/channel/_components/chatting/ChatList.tsx
@@ -1,17 +1,41 @@
 import { useEffect, useRef } from 'react';
 
+import send from '@/services/websocket/send';
+import { UserJoinReq } from '@/services/websocket/type';
 import { useUserStore } from '@/stores/User';
 import { useSocketStore } from '@/stores/useSocketStore';
+import { SEVER_NICKNAME } from '@/utils/constants';
 
 import Message from './Message';
 import ServerMessage from './ServerMessage';
 
-export function ChatList() {
+interface ChatListProps {
+  channelId: string;
+}
+
+export function ChatList({ channelId }: ChatListProps) {
   const chatListRef = useRef<HTMLDivElement>(null);
 
-  const { chatting } = useSocketStore((state) => ({
-    chatting: state.chatting,
+  const { user_id, nickname } = useUserStore((state) => ({
+    user_id: state.user_id,
+    nickname: state.nickname,
   }));
+
+  const { chatting, isConnected } = useSocketStore((state) => ({
+    chatting: state.chatting,
+    isConnected: state.isConnected,
+  }));
+
+  const sendJoinMessage = () => {
+    const joinReqForm: UserJoinReq = {
+      channel_id: channelId,
+      sender: user_id,
+      content: `${user_id} joined the channel`,
+      type: 'USER_JOIN',
+    };
+
+    send('USER_JOIN', joinReqForm);
+  };
 
   useEffect(() => {
     if (chatListRef.current) {
@@ -19,15 +43,24 @@ export function ChatList() {
     }
   }, [chatting]);
 
+  useEffect(() => {
+    if (user_id && isConnected) {
+      sendJoinMessage();
+    }
+  }, [user_id, channelId, isConnected]);
+
   return (
     <div
       ref={chatListRef}
       className={`h-[254px] w-full grow overflow-y-auto px-0 no-scrollbar desktop:h-screen-chatList desktop:w-[440px] desktop:px-8`}
     >
       <div className="flex-col items-end gap-0.5">
-        {/* {session && <ServerMessage>{nickname}님, 채팅이 시작되었어요!</ServerMessage>} */}
-        {chatting.map((chat) => {
-          return <Message key={chat?.user_id + chat?.sendTime} {...chat} />;
+        {chatting.map((chat, index) => {
+          if (chat.user_id === SEVER_NICKNAME)
+            return <ServerMessage key={chat?.user_id + chat?.sendTime + index} {...chat} />;
+          return (
+            <Message key={chat?.user_id + chat?.sendTime + index} myNickname={nickname} {...chat} />
+          );
         })}
       </div>
     </div>

--- a/src/app/channel/_components/chatting/ChatList.tsx
+++ b/src/app/channel/_components/chatting/ChatList.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useRef } from 'react';
 
-import { useSession } from 'next-auth/react';
-
+import { useUserStore } from '@/stores/User';
 import { useSocketStore } from '@/stores/useSocketStore';
 
 import Message from './Message';
@@ -9,10 +8,11 @@ import ServerMessage from './ServerMessage';
 
 export function ChatList() {
   const chatListRef = useRef<HTMLDivElement>(null);
-  const { data: session } = useSession();
-  const nickname = session && session.user?.name;
 
-  const chatting = useSocketStore((state) => state.chatting);
+  const { chatting, userJoin } = useSocketStore((state) => ({
+    chatting: state.chatting,
+    userJoin: state.userJoin,
+  }));
 
   useEffect(() => {
     if (chatListRef.current) {
@@ -23,10 +23,10 @@ export function ChatList() {
   return (
     <div
       ref={chatListRef}
-      className={`no-scrollbar h-[254px] w-full grow overflow-y-auto px-0 desktop:h-screen-chatList desktop:w-[440px] desktop:px-8`}
+      className={`h-[254px] w-full grow overflow-y-auto px-0 no-scrollbar desktop:h-screen-chatList desktop:w-[440px] desktop:px-8`}
     >
       <div className="flex-col items-end gap-0.5">
-        {session && <ServerMessage>{nickname}님, 채팅이 시작되었어요!</ServerMessage>}
+        {/* {session && <ServerMessage>{nickname}님, 채팅이 시작되었어요!</ServerMessage>} */}
         {chatting.map((chat) => {
           return <Message key={chat?.user_id + chat?.sendTime} {...chat} />;
         })}

--- a/src/app/channel/_components/chatting/ChatList.tsx
+++ b/src/app/channel/_components/chatting/ChatList.tsx
@@ -9,9 +9,8 @@ import ServerMessage from './ServerMessage';
 export function ChatList() {
   const chatListRef = useRef<HTMLDivElement>(null);
 
-  const { chatting, userJoin } = useSocketStore((state) => ({
+  const { chatting } = useSocketStore((state) => ({
     chatting: state.chatting,
-    userJoin: state.userJoin,
   }));
 
   useEffect(() => {

--- a/src/app/channel/_components/chatting/Message.tsx
+++ b/src/app/channel/_components/chatting/Message.tsx
@@ -3,18 +3,23 @@
 import { memo } from 'react';
 
 import Image from 'next/image';
-import { useSession } from 'next-auth/react';
 
 interface MessageProps {
+  myNickname: string;
   nickname: string;
   profile_color: string;
   profile_image?: string | null;
   message: string;
 }
 
-const Message = ({ nickname, profile_color, profile_image = null, message }: MessageProps) => {
-  const { data: session } = useSession();
-  const isMe = session && session.user?.name === nickname;
+const Message = ({
+  myNickname,
+  nickname,
+  profile_color,
+  profile_image = null,
+  message,
+}: MessageProps) => {
+  const isMe = myNickname === nickname;
   const image = profile_image ?? '/default-profile-image.png';
   const nicknameColor = profile_color ?? '#00FFFF';
 

--- a/src/app/channel/_components/chatting/ServerMessage.tsx
+++ b/src/app/channel/_components/chatting/ServerMessage.tsx
@@ -1,14 +1,16 @@
-import { ReactNode, memo } from 'react';
+import { memo } from 'react';
 
 interface ServerMessageProps {
-  children: ReactNode;
+  nickname: string;
+  message: string;
 }
 
-const ServerMessage = ({ children }: ServerMessageProps) => {
+const ServerMessage = ({ nickname, message }: ServerMessageProps) => {
   return (
     <div className="flex w-full justify-center py-3">
       <span className="rounded-full bg-neutral-400 px-4 py-1 text-neutral-100 micro-regular">
-        {children}
+        {nickname}
+        {message}
       </span>
     </div>
   );

--- a/src/app/channel/_components/chatting/TextareaField.tsx
+++ b/src/app/channel/_components/chatting/TextareaField.tsx
@@ -28,6 +28,10 @@ export default function TextareaField({
     profile_image: state.profile_image,
   }));
 
+  const { isConnected } = useSocketStore((state) => ({
+    isConnected: state.isConnected,
+  }));
+
   const sendChatMessage = () => {
     const chatReqForm: UserChatReq = {
       nickname: nickname,
@@ -37,8 +41,6 @@ export default function TextareaField({
     };
 
     send('USER_CHAT', chatReqForm);
-
-    sendJoinMessage(); // 여기에 넣어서 테스트해봐도 안되네요ㅜ
     setMessage('');
   };
 
@@ -60,16 +62,11 @@ export default function TextareaField({
     send('USER_JOIN', joinReqForm);
   };
 
-  const { chatting, userJoin } = useSocketStore((state) => ({
-    chatting: state.chatting,
-    userJoin: state.userJoin,
-  }));
-
   useEffect(() => {
-    if (user_id) {
-      sendJoinMessage(); // 여기에 넣으면 웹소켓 연결이 활성화 안되었다는 에러가 납니다.
+    if (user_id && isConnected) {
+      sendJoinMessage();
     }
-  }, [user_id, channelId]);
+  }, [user_id, channelId, isConnected]);
 
   return (
     <div className="flex w-full items-end gap-3 px-0 py-3 desktop:w-[440px] desktop:px-8">

--- a/src/app/channel/_components/chatting/TextareaField.tsx
+++ b/src/app/channel/_components/chatting/TextareaField.tsx
@@ -1,35 +1,24 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
 import send from '@/services/websocket/send';
-import { UserChatReq, UserJoinReq } from '@/services/websocket/type';
+import { UserChatReq } from '@/services/websocket/type';
 import { useUserStore } from '@/stores/User';
-import { useSocketStore } from '@/stores/useSocketStore';
 import { Send } from 'lucide-react';
 
 interface TextareaFieldProps {
   disabled?: boolean;
-  channelId: string;
   onClick?: () => void;
 }
 
-export default function TextareaField({
-  channelId,
-  disabled = false,
-  onClick,
-}: TextareaFieldProps) {
+export default function TextareaField({ disabled = false, onClick }: TextareaFieldProps) {
   const [message, setMessage] = useState('');
 
-  const { user_id, nickname, profile_color, profile_image } = useUserStore((state) => ({
-    user_id: state.user_id,
+  const { nickname, profile_color, profile_image } = useUserStore((state) => ({
     nickname: state.nickname,
     profile_color: state.profile_color,
     profile_image: state.profile_image,
-  }));
-
-  const { isConnected } = useSocketStore((state) => ({
-    isConnected: state.isConnected,
   }));
 
   const sendChatMessage = () => {
@@ -50,23 +39,6 @@ export default function TextareaField({
       sendChatMessage();
     }
   };
-
-  const sendJoinMessage = () => {
-    const joinReqForm: UserJoinReq = {
-      channel_id: channelId,
-      sender: user_id,
-      content: `${user_id} joined the channel`,
-      type: 'USER_JOIN',
-    };
-
-    send('USER_JOIN', joinReqForm);
-  };
-
-  useEffect(() => {
-    if (user_id && isConnected) {
-      sendJoinMessage();
-    }
-  }, [user_id, channelId, isConnected]);
 
   return (
     <div className="flex w-full items-end gap-3 px-0 py-3 desktop:w-[440px] desktop:px-8">

--- a/src/app/channel/_components/chatting/TextareaField.tsx
+++ b/src/app/channel/_components/chatting/TextareaField.tsx
@@ -1,11 +1,12 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
 import send from '@/services/websocket/send';
-import { UserChatReq } from '@/services/websocket/type';
+import { UserChatReq, UserJoinReq } from '@/services/websocket/type';
+import { useUserStore } from '@/stores/User';
+import { useSocketStore } from '@/stores/useSocketStore';
 import { Send } from 'lucide-react';
-import { useSession } from 'next-auth/react';
 
 interface TextareaFieldProps {
   disabled?: boolean;
@@ -13,48 +14,62 @@ interface TextareaFieldProps {
   onClick?: () => void;
 }
 
-export default function TextareaField({ disabled = false, onClick }: TextareaFieldProps) {
+export default function TextareaField({
+  channelId,
+  disabled = false,
+  onClick,
+}: TextareaFieldProps) {
   const [message, setMessage] = useState('');
 
-  const { data: session } = useSession();
-  const userData = session?.user ?? { name: '', email: '', image: null };
-
-  /** User 상태관리로 교체할때 사용
-   const { nickname, profile_color, profile_image } = useUserStore((state) => ({
-     nickname: state.nickname,
+  const { user_id, nickname, profile_color, profile_image } = useUserStore((state) => ({
+    user_id: state.user_id,
+    nickname: state.nickname,
     profile_color: state.profile_color,
     profile_image: state.profile_image,
   }));
 
-  console.log(nickname, profile_color, profile_image); */
+  const sendChatMessage = () => {
+    const chatReqForm: UserChatReq = {
+      nickname: nickname,
+      profile_image: profile_image,
+      profile_color: profile_color,
+      message: message,
+    };
 
-  const sendMessage = () => {
-    if (message.trim() !== '') {
-      const messageToSend: UserChatReq = {
-        nickname: userData.name as string,
-        profile_image: userData.image as string,
-        profile_color: null,
-        message: message,
-      };
-      /** User 상태관리로 교체할때 사용
-      const messageToSend: UserChatReq = {
-        nickname: nickname,
-        profile_image: profile_image,
-        profile_color: profile_color,
-        message: message,
-      }; */
+    send('USER_CHAT', chatReqForm);
 
-      send('USER_CHAT', messageToSend);
-      setMessage('');
-    }
+    sendJoinMessage(); // 여기에 넣어서 테스트해봐도 안되네요ㅜ
+    setMessage('');
   };
 
   const handleEnter = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if (e.key === 'Enter' && !e.nativeEvent.isComposing) {
       e.preventDefault();
-      sendMessage();
+      sendChatMessage();
     }
   };
+
+  const sendJoinMessage = () => {
+    const joinReqForm: UserJoinReq = {
+      channel_id: channelId,
+      sender: user_id,
+      content: `${user_id} joined the channel`,
+      type: 'USER_JOIN',
+    };
+
+    send('USER_JOIN', joinReqForm);
+  };
+
+  const { chatting, userJoin } = useSocketStore((state) => ({
+    chatting: state.chatting,
+    userJoin: state.userJoin,
+  }));
+
+  useEffect(() => {
+    if (user_id) {
+      sendJoinMessage(); // 여기에 넣으면 웹소켓 연결이 활성화 안되었다는 에러가 납니다.
+    }
+  }, [user_id, channelId]);
 
   return (
     <div className="flex w-full items-end gap-3 px-0 py-3 desktop:w-[440px] desktop:px-8">
@@ -70,7 +85,7 @@ export default function TextareaField({ disabled = false, onClick }: TextareaFie
         rows={1}
         disabled={disabled}
       />
-      <Button variant="active" size="icon" onClick={sendMessage}>
+      <Button variant="active" size="icon" onClick={sendChatMessage}>
         <Send />
       </Button>
     </div>

--- a/src/app/channel/_components/chatting/index.tsx
+++ b/src/app/channel/_components/chatting/index.tsx
@@ -2,11 +2,10 @@
 
 import { useState } from 'react';
 
-import { useRouter } from 'next/navigation';
-import { useSession } from 'next-auth/react';
-
 import ConfirmModal from '@/components/modal/ConfirmModal';
 import { PAGE_ROUTE } from '@/utils/route';
+import { useRouter } from 'next/navigation';
+import { useSession } from 'next-auth/react';
 
 import ChatHeader from './ChatHeader';
 import { ChatList } from './ChatList';

--- a/src/app/channel/_components/chatting/index.tsx
+++ b/src/app/channel/_components/chatting/index.tsx
@@ -33,10 +33,8 @@ const Chatting = ({ channelId }: ChattingProps) => {
       className={`mt-4 flex min-h-[385px] w-full flex-col overflow-hidden desktop:order-3 desktop:mt-0 desktop:max-h-screen desktop:max-w-[440px] ${isFold && 'min-h-[67px] desktop:max-w-[88px]'}`}
     >
       <ChatHeader isFold={isFold} setIsFold={setIsFold} />
-      {!isFold && <ChatList />}
-      {!isFold && (
-        <TextareaField channelId={channelId} disabled={false} onClick={handleClickChat} />
-      )}
+      {!isFold && <ChatList channelId={channelId} />}
+      {!isFold && <TextareaField disabled={false} onClick={handleClickChat} />}
       {showLoginModal && (
         <ConfirmModal
           leftButtonText="취소"

--- a/src/services/websocket/index.ts
+++ b/src/services/websocket/index.ts
@@ -1,6 +1,7 @@
 import { Client } from '@stomp/stompjs';
 import SockJS from 'sockjs-client';
 
+import { useSocketStore } from '@/stores/useSocketStore';
 import { getSession } from 'next-auth/react';
 
 import type { IFrame, IMessage, IStompSocket } from '@stomp/stompjs';
@@ -8,6 +9,8 @@ import type { IFrame, IMessage, IStompSocket } from '@stomp/stompjs';
 const createStompClient = () => {
   const client = new Client();
   const BASE_URL = process.env.NEXT_PUBLIC_WEBSOCKET_SERVER_URL;
+
+  const { isConnected, setIsConnected } = useSocketStore.getState();
 
   /** 소켓 연결 */
   const connect = async (channelId: string, onMessageCallback: (message: IMessage) => void) => {
@@ -21,6 +24,7 @@ const createStompClient = () => {
 
     client.onConnect = () => {
       client.subscribe(`/channel/${channelId}`, onMessageCallback);
+      setIsConnected(true);
     };
 
     client.onStompError = (frame: IFrame) => {
@@ -34,75 +38,13 @@ const createStompClient = () => {
   /** 소캣 연결 해제 */
   const disconnect = () => {
     client.deactivate();
+    setIsConnected(false);
   };
 
   const send = (endpoint: string, message: object) => {
     client.publish({ destination: endpoint, body: JSON.stringify(message) });
   };
-  return { connect, disconnect, send };
+  return { connect, disconnect, send, isConnected };
 };
 
 export const stomp = createStompClient();
-
-//
-
-// import { Client } from '@stomp/stompjs';
-// import SockJS from 'sockjs-client';
-
-// import { getSession } from 'next-auth/react';
-
-// import type { IFrame, IMessage, IStompSocket } from '@stomp/stompjs';
-
-// const createStompClient = () => {
-//   const client = new Client();
-//   const BASE_URL = process.env.NEXT_PUBLIC_WEBSOCKET_SERVER_URL;
-//   let isConnected = false;
-
-//   /** 소켓 연결 */
-//   const connect = async (
-//     channelId: string,
-//     onMessageCallback: (message: IMessage) => void,
-//     onConnect?: () => void,
-//     onDisconnect?: () => void,
-//   ) => {
-//     const session = await getSession();
-
-//     const url = await new URL(
-//       `/ws?channel=${channelId}${session?.user.accessToken ? `&token=${session.user.accessToken}` : ''}`,
-//       BASE_URL,
-//     ).toString();
-//     client.webSocketFactory = () => new SockJS(url) as IStompSocket;
-
-//     client.onConnect = () => {
-//       isConnected = true;
-//       client.subscribe(`/channel/${channelId}`, onMessageCallback);
-//     };
-
-//     client.onDisconnect = () => {
-//       isConnected = false;
-//     };
-
-//     client.onStompError = (frame: IFrame) => {
-//       console.error('STOMP 오류', frame.headers['message']);
-//       console.error(frame.body);
-//     };
-
-//     client.activate();
-//   };
-
-//   /** 소캣 연결 해제 */
-//   const disconnect = () => {
-//     client.deactivate();
-//   };
-
-//   const send = (endpoint: string, message: object) => {
-//     if (client.connected) {
-//       client.publish({ destination: endpoint, body: JSON.stringify(message) });
-//     } else {
-//       console.error('웹소켓 연결이 활성화되지 않았습니다.');
-//     }
-//   };
-//   return { connect, disconnect, send, isConnected };
-// };
-
-// export const stomp = createStompClient();

--- a/src/services/websocket/index.ts
+++ b/src/services/websocket/index.ts
@@ -43,3 +43,66 @@ const createStompClient = () => {
 };
 
 export const stomp = createStompClient();
+
+//
+
+// import { Client } from '@stomp/stompjs';
+// import SockJS from 'sockjs-client';
+
+// import { getSession } from 'next-auth/react';
+
+// import type { IFrame, IMessage, IStompSocket } from '@stomp/stompjs';
+
+// const createStompClient = () => {
+//   const client = new Client();
+//   const BASE_URL = process.env.NEXT_PUBLIC_WEBSOCKET_SERVER_URL;
+//   let isConnected = false;
+
+//   /** 소켓 연결 */
+//   const connect = async (
+//     channelId: string,
+//     onMessageCallback: (message: IMessage) => void,
+//     onConnect?: () => void,
+//     onDisconnect?: () => void,
+//   ) => {
+//     const session = await getSession();
+
+//     const url = await new URL(
+//       `/ws?channel=${channelId}${session?.user.accessToken ? `&token=${session.user.accessToken}` : ''}`,
+//       BASE_URL,
+//     ).toString();
+//     client.webSocketFactory = () => new SockJS(url) as IStompSocket;
+
+//     client.onConnect = () => {
+//       isConnected = true;
+//       client.subscribe(`/channel/${channelId}`, onMessageCallback);
+//     };
+
+//     client.onDisconnect = () => {
+//       isConnected = false;
+//     };
+
+//     client.onStompError = (frame: IFrame) => {
+//       console.error('STOMP 오류', frame.headers['message']);
+//       console.error(frame.body);
+//     };
+
+//     client.activate();
+//   };
+
+//   /** 소캣 연결 해제 */
+//   const disconnect = () => {
+//     client.deactivate();
+//   };
+
+//   const send = (endpoint: string, message: object) => {
+//     if (client.connected) {
+//       client.publish({ destination: endpoint, body: JSON.stringify(message) });
+//     } else {
+//       console.error('웹소켓 연결이 활성화되지 않았습니다.');
+//     }
+//   };
+//   return { connect, disconnect, send, isConnected };
+// };
+
+// export const stomp = createStompClient();

--- a/src/services/websocket/send.ts
+++ b/src/services/websocket/send.ts
@@ -36,25 +36,3 @@ const send = <T extends keyof typeof ENDPOINT>(type: T, message: SendMessageType
 };
 
 export default send;
-
-// import { stomp } from '.';
-// import { UserChatReq } from './type';
-
-// const ENDPOINT = {
-//   USER_JOIN: '/stomp/user.join',
-//   USER_LEAVE: '/stomp/user.leave',
-//   USER_CHAT: '/stomp/user.chat',
-// } as const;
-
-// type SendMessageType = {
-//   USER_JOIN: object;
-//   USER_LEAVE: object;
-//   USER_CHAT: UserChatReq;
-// };
-
-// const send = <T extends keyof typeof ENDPOINT>(type: T, message: SendMessageType[T]) => {
-//   if (!stomp) return;
-//   stomp.send(ENDPOINT[type], message);
-// };
-
-// export default send;

--- a/src/services/websocket/send.ts
+++ b/src/services/websocket/send.ts
@@ -36,3 +36,25 @@ const send = <T extends keyof typeof ENDPOINT>(type: T, message: SendMessageType
 };
 
 export default send;
+
+// import { stomp } from '.';
+// import { UserChatReq } from './type';
+
+// const ENDPOINT = {
+//   USER_JOIN: '/stomp/user.join',
+//   USER_LEAVE: '/stomp/user.leave',
+//   USER_CHAT: '/stomp/user.chat',
+// } as const;
+
+// type SendMessageType = {
+//   USER_JOIN: object;
+//   USER_LEAVE: object;
+//   USER_CHAT: UserChatReq;
+// };
+
+// const send = <T extends keyof typeof ENDPOINT>(type: T, message: SendMessageType[T]) => {
+//   if (!stomp) return;
+//   stomp.send(ENDPOINT[type], message);
+// };
+
+// export default send;

--- a/src/services/websocket/type.ts
+++ b/src/services/websocket/type.ts
@@ -8,6 +8,14 @@ export type UserChatReq = {
   message: string;
 };
 
+/** 채널 입장 */
+export type UserJoinReq = {
+  channel_id: string;
+  sender: string;
+  content: string;
+  type: 'USER_JOIN';
+};
+
 /** 영상 재생/일시정지 */
 export type VideoPlayReq = {
   playlist_no: number;
@@ -57,7 +65,8 @@ export type MessageType = {
 
   /** 사용자 입장 알림 */
   USER_JOIN: {
-    user_id: string;
+    user_id: string | 'NONE';
+    nickname: string;
   };
 
   /** 사용자 퇴장 알림 */

--- a/src/stores/useSocketStore.ts
+++ b/src/stores/useSocketStore.ts
@@ -1,6 +1,6 @@
 import { Playlist } from '@/services/playlist/type';
 import { MessageType } from '@/services/websocket/type';
-import { ServerChattingForm } from '@/utils/constants';
+import { SEVER_CHAT_MESSAGE, SEVER_NICKNAME, ServerChatForm } from '@/utils/constants';
 import { create } from 'zustand';
 
 type ChattingType = MessageType['USER_CHAT'];
@@ -65,14 +65,32 @@ export const useSocketStore = create<SocketStore>((set) => ({
         set((state) => ({ chatting: [...state.chatting, action.payload] }));
         break;
       case 'SET_JOIN':
-        // set({ userJoin: action.payload });
         set((state) => ({
-          chatting: [...state.chatting, { ...ServerChattingForm, message: action.payload.user_id }],
+          chatting: [
+            ...state.chatting,
+            {
+              ...ServerChatForm,
+              user_id: SEVER_NICKNAME,
+              nickname: action.payload.nickname,
+              message: SEVER_CHAT_MESSAGE.USER_JOIN,
+            },
+          ],
           userJoin: action.payload,
         }));
         break;
       case 'SET_LEAVE':
-        set({ userLeave: action.payload });
+        set((state) => ({
+          chatting: [
+            ...state.chatting,
+            {
+              ...ServerChatForm,
+              user_id: SEVER_NICKNAME,
+              nickname: action.payload.user_id,
+              message: SEVER_CHAT_MESSAGE.USER_LEAVE,
+            },
+          ],
+          userLeave: action.payload,
+        }));
         break;
       case 'SET_PLAYLIST':
         if (Array.isArray(action.payload)) {

--- a/src/stores/useSocketStore.ts
+++ b/src/stores/useSocketStore.ts
@@ -1,75 +1,3 @@
-// import { Playlist } from '@/services/playlist/type';
-// import { MessageType } from '@/services/websocket/type';
-// import { create } from 'zustand';
-
-// type ChattingType = MessageType['USER_CHAT'];
-// type VideoType = MessageType['VIDEO_PLAY'] & MessageType['VIDEO_MOVE'] & { url: string };
-
-// interface SocketStore {
-//   chatting: ChattingType[];
-//   playlist: Playlist[];
-//   video: VideoType;
-//   viewer: MessageType['CHANNEL_VIEWER'];
-
-//   /** 스토어 초기화 */
-//   resetStore: () => void;
-
-//   setSocketStore: (action: Action) => void;
-// }
-
-// const initialData: Pick<SocketStore, 'chatting' | 'playlist' | 'video' | 'viewer'> = {
-//   chatting: [],
-//   playlist: [],
-//   viewer: { anonymous_users: 0, login_users: 0, total_users: 0 },
-//   video: { playlist_no: -1, playing: false, playtime: 0, url: '' },
-// };
-
-// type Action =
-//   | { type: 'SET_VIEWER'; payload: MessageType['CHANNEL_VIEWER'] }
-//   | { type: 'SET_CHATTING'; payload: ChattingType }
-//   | { type: 'SET_PLAYLIST'; payload: Playlist[] | Playlist }
-//   | { type: 'PLAYLIST_REMOVE'; payload: number }
-//   | { type: 'SET_VIDEO'; payload: VideoType }
-//   | { type: 'RESET_STORE' };
-
-// export const useSocketStore = create<SocketStore>((set) => ({
-//   chatting: initialData.chatting,
-//   playlist: initialData.playlist,
-//   video: initialData.video,
-//   viewer: initialData.viewer,
-//   resetStore: () => set(initialData),
-//   setSocketStore: (action: Action) => {
-//     switch (action.type) {
-//       case 'SET_CHATTING':
-//         set((state) => ({ chatting: [...state.chatting, action.payload] }));
-//         break;
-//       case 'SET_PLAYLIST':
-//         if (Array.isArray(action.payload)) {
-//           set({ playlist: action.payload });
-//         } else {
-//           const { ...rest } = action.payload;
-//           set((state) => ({ playlist: [...state.playlist, rest] }));
-//         }
-//         break;
-//       case 'PLAYLIST_REMOVE':
-//         set((state) => ({
-//           playlist: state.playlist.filter((video) => video.playlist_no !== action.payload),
-//         }));
-//         break;
-//       case 'SET_VIDEO':
-//         set({ video: action.payload });
-//         break;
-//       case 'SET_VIEWER':
-//         set({ viewer: action.payload });
-//         break;
-//       default:
-//         break;
-//     }
-//   },
-// }));
-
-//
-
 import { Playlist } from '@/services/playlist/type';
 import { MessageType } from '@/services/websocket/type';
 import { ServerChattingForm } from '@/utils/constants';
@@ -87,6 +15,8 @@ interface SocketStore {
   playlist: Playlist[];
   video: VideoType;
   viewer: MessageType['CHANNEL_VIEWER'];
+  isConnected: boolean;
+  setIsConnected: (flag: boolean) => void;
 
   /** 스토어 초기화 */
   resetStore: () => void;
@@ -96,7 +26,7 @@ interface SocketStore {
 
 const initialData: Pick<
   SocketStore,
-  'chatting' | 'userJoin' | 'userLeave' | 'playlist' | 'video' | 'viewer'
+  'chatting' | 'userJoin' | 'userLeave' | 'playlist' | 'video' | 'viewer' | 'isConnected'
 > = {
   chatting: [],
   userJoin: { user_id: '', nickname: '' },
@@ -104,6 +34,7 @@ const initialData: Pick<
   playlist: [],
   viewer: { anonymous_users: 0, login_users: 0, total_users: 0 },
   video: { playlist_no: -1, playing: false, playtime: 0, url: '' },
+  isConnected: false,
 };
 
 type Action =
@@ -114,6 +45,7 @@ type Action =
   | { type: 'SET_PLAYLIST'; payload: Playlist[] | Playlist }
   | { type: 'PLAYLIST_REMOVE'; payload: number }
   | { type: 'SET_VIDEO'; payload: VideoType }
+  | { type: 'SET_CONNECTED'; payload: boolean }
   | { type: 'RESET_STORE' };
 
 export const useSocketStore = create<SocketStore>((set) => ({
@@ -123,6 +55,8 @@ export const useSocketStore = create<SocketStore>((set) => ({
   playlist: initialData.playlist,
   video: initialData.video,
   viewer: initialData.viewer,
+  isConnected: initialData.isConnected,
+  setIsConnected: (flag) => set({ isConnected: flag }),
 
   resetStore: () => set(initialData),
   setSocketStore: (action: Action) => {
@@ -131,11 +65,11 @@ export const useSocketStore = create<SocketStore>((set) => ({
         set((state) => ({ chatting: [...state.chatting, action.payload] }));
         break;
       case 'SET_JOIN':
-        set({ userJoin: action.payload });
-        // set((state) => ({
-        //   chatting: [...state.chatting, { ...ServerChattingForm, message: action.payload.user_id }],
-        //   userJoin: action.payload,
-        // }));
+        // set({ userJoin: action.payload });
+        set((state) => ({
+          chatting: [...state.chatting, { ...ServerChattingForm, message: action.payload.user_id }],
+          userJoin: action.payload,
+        }));
         break;
       case 'SET_LEAVE':
         set({ userLeave: action.payload });
@@ -158,6 +92,9 @@ export const useSocketStore = create<SocketStore>((set) => ({
         break;
       case 'SET_VIEWER':
         set({ viewer: action.payload });
+        break;
+      case 'SET_CONNECTED':
+        set({ isConnected: action.payload });
         break;
       default:
         break;

--- a/src/stores/useSocketStore.ts
+++ b/src/stores/useSocketStore.ts
@@ -1,12 +1,89 @@
+// import { Playlist } from '@/services/playlist/type';
+// import { MessageType } from '@/services/websocket/type';
+// import { create } from 'zustand';
+
+// type ChattingType = MessageType['USER_CHAT'];
+// type VideoType = MessageType['VIDEO_PLAY'] & MessageType['VIDEO_MOVE'] & { url: string };
+
+// interface SocketStore {
+//   chatting: ChattingType[];
+//   playlist: Playlist[];
+//   video: VideoType;
+//   viewer: MessageType['CHANNEL_VIEWER'];
+
+//   /** 스토어 초기화 */
+//   resetStore: () => void;
+
+//   setSocketStore: (action: Action) => void;
+// }
+
+// const initialData: Pick<SocketStore, 'chatting' | 'playlist' | 'video' | 'viewer'> = {
+//   chatting: [],
+//   playlist: [],
+//   viewer: { anonymous_users: 0, login_users: 0, total_users: 0 },
+//   video: { playlist_no: -1, playing: false, playtime: 0, url: '' },
+// };
+
+// type Action =
+//   | { type: 'SET_VIEWER'; payload: MessageType['CHANNEL_VIEWER'] }
+//   | { type: 'SET_CHATTING'; payload: ChattingType }
+//   | { type: 'SET_PLAYLIST'; payload: Playlist[] | Playlist }
+//   | { type: 'PLAYLIST_REMOVE'; payload: number }
+//   | { type: 'SET_VIDEO'; payload: VideoType }
+//   | { type: 'RESET_STORE' };
+
+// export const useSocketStore = create<SocketStore>((set) => ({
+//   chatting: initialData.chatting,
+//   playlist: initialData.playlist,
+//   video: initialData.video,
+//   viewer: initialData.viewer,
+//   resetStore: () => set(initialData),
+//   setSocketStore: (action: Action) => {
+//     switch (action.type) {
+//       case 'SET_CHATTING':
+//         set((state) => ({ chatting: [...state.chatting, action.payload] }));
+//         break;
+//       case 'SET_PLAYLIST':
+//         if (Array.isArray(action.payload)) {
+//           set({ playlist: action.payload });
+//         } else {
+//           const { ...rest } = action.payload;
+//           set((state) => ({ playlist: [...state.playlist, rest] }));
+//         }
+//         break;
+//       case 'PLAYLIST_REMOVE':
+//         set((state) => ({
+//           playlist: state.playlist.filter((video) => video.playlist_no !== action.payload),
+//         }));
+//         break;
+//       case 'SET_VIDEO':
+//         set({ video: action.payload });
+//         break;
+//       case 'SET_VIEWER':
+//         set({ viewer: action.payload });
+//         break;
+//       default:
+//         break;
+//     }
+//   },
+// }));
+
+//
+
 import { Playlist } from '@/services/playlist/type';
 import { MessageType } from '@/services/websocket/type';
+import { ServerChattingForm } from '@/utils/constants';
 import { create } from 'zustand';
 
 type ChattingType = MessageType['USER_CHAT'];
+type UserJoinType = MessageType['USER_JOIN'];
+type UserLeaveType = MessageType['USER_LEAVE'];
 type VideoType = MessageType['VIDEO_PLAY'] & MessageType['VIDEO_MOVE'] & { url: string };
 
 interface SocketStore {
   chatting: ChattingType[];
+  userJoin: UserJoinType;
+  userLeave: UserLeaveType;
   playlist: Playlist[];
   video: VideoType;
   viewer: MessageType['CHANNEL_VIEWER'];
@@ -17,8 +94,13 @@ interface SocketStore {
   setSocketStore: (action: Action) => void;
 }
 
-const initialData: Pick<SocketStore, 'chatting' | 'playlist' | 'video' | 'viewer'> = {
+const initialData: Pick<
+  SocketStore,
+  'chatting' | 'userJoin' | 'userLeave' | 'playlist' | 'video' | 'viewer'
+> = {
   chatting: [],
+  userJoin: { user_id: '', nickname: '' },
+  userLeave: { user_id: '' },
   playlist: [],
   viewer: { anonymous_users: 0, login_users: 0, total_users: 0 },
   video: { playlist_no: -1, playing: false, playtime: 0, url: '' },
@@ -27,6 +109,8 @@ const initialData: Pick<SocketStore, 'chatting' | 'playlist' | 'video' | 'viewer
 type Action =
   | { type: 'SET_VIEWER'; payload: MessageType['CHANNEL_VIEWER'] }
   | { type: 'SET_CHATTING'; payload: ChattingType }
+  | { type: 'SET_JOIN'; payload: MessageType['USER_JOIN'] }
+  | { type: 'SET_LEAVE'; payload: MessageType['USER_LEAVE'] }
   | { type: 'SET_PLAYLIST'; payload: Playlist[] | Playlist }
   | { type: 'PLAYLIST_REMOVE'; payload: number }
   | { type: 'SET_VIDEO'; payload: VideoType }
@@ -34,14 +118,27 @@ type Action =
 
 export const useSocketStore = create<SocketStore>((set) => ({
   chatting: initialData.chatting,
+  userJoin: initialData.userJoin,
+  userLeave: initialData.userLeave,
   playlist: initialData.playlist,
   video: initialData.video,
   viewer: initialData.viewer,
+
   resetStore: () => set(initialData),
   setSocketStore: (action: Action) => {
     switch (action.type) {
       case 'SET_CHATTING':
         set((state) => ({ chatting: [...state.chatting, action.payload] }));
+        break;
+      case 'SET_JOIN':
+        set({ userJoin: action.payload });
+        // set((state) => ({
+        //   chatting: [...state.chatting, { ...ServerChattingForm, message: action.payload.user_id }],
+        //   userJoin: action.payload,
+        // }));
+        break;
+      case 'SET_LEAVE':
+        set({ userLeave: action.payload });
         break;
       case 'SET_PLAYLIST':
         if (Array.isArray(action.payload)) {

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,3 +1,12 @@
 export const PLACEHOLDER = {
   CHANNEL_SEARCHBAR: '채널명, 해시태그를 검색해 보세요!',
 };
+
+export const ServerChattingForm = {
+  message: '',
+  nickname: 'PARTAGE_SERVER',
+  profile_color: '',
+  profile_image: '',
+  sendTime: new Date().toISOString(),
+  user_id: 'NONE',
+};

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -2,11 +2,18 @@ export const PLACEHOLDER = {
   CHANNEL_SEARCHBAR: '채널명, 해시태그를 검색해 보세요!',
 };
 
-export const ServerChattingForm = {
+export const SEVER_NICKNAME = 'PARTAGE_SERVER';
+
+export const ServerChatForm = {
   message: '',
-  nickname: 'PARTAGE_SERVER',
+  nickname: SEVER_NICKNAME,
   profile_color: '',
   profile_image: '',
   sendTime: new Date().toISOString(),
   user_id: 'NONE',
+};
+
+export const SEVER_CHAT_MESSAGE = {
+  USER_JOIN: '님이 들어왔어요.',
+  USER_LEAVE: '님이 잠시 떠났어요.',
 };


### PR DESCRIPTION
## 관련 이슈

#71 

<!-- 관련된 이슈를 여기에 링크해 주세요: -->
<br/>

## 변경 유형

- [x] `feat` 새로운 기능
- [ ] `refactor` 코드 리팩토링
- [ ] `fix` 버그 수정
- [ ] `design` 사용자 UI 디자인 변경
- [ ] `comment` 주석 추가 및 변경
- [ ] `test` 테스트 코드 추가
- [ ] `docs` 문서 업데이트
- [ ] `style` 코드 포맷팅
- [ ] `chore` 빌드, 패키지 매니저, 설정 파일 변경
- [ ] `rename` 파일/폴더명 수정
- [ ] `remove` 파일 삭제

## 변경사항 요약

- /channel/:channelId에 로그인한 유저 입장시 채팅창에 서버메시지 띄우기 구현

  <!-- 변경 사항에 대한 요약을 작성해주세요. -->

  <br/>

## 변경 내용

- useSocketStore에 isConnected와 setIsConnected를 추가하여 연결상태 관리를 하였습니다. 
- createStopClient에 client에 웹소켓 연결에 따라 isConnected 상태를 업데이트할 수 있도록 하였습니다. 
- ChatList에서 useEffect로 /channel/:channelId에 들어왔을때 바로 로인한 유저의 채팅방 입장을 서버에 알렸습니다.(이때 리액트 라이프사이클 문제로 에러가 발생했는데 이걸 isConnected가 true일때만 send 되도록 변경하여 해결하였습니다)
**시온님 도움 감사합니다! 


## 추가 정보

<!-- 필요 시 전달 사항, 참고 자료 등을 추가해주세요. -->
<br/>


![입장](https://github.com/user-attachments/assets/d4c7764d-f11d-4474-ad51-fb3688b059d4)

