### PR TITLE
플레이리스트 순서 변경 로직 수정

### DIFF
--- a/src/app/channel/_components/SocketConnector.tsx
+++ b/src/app/channel/_components/SocketConnector.tsx
@@ -56,7 +56,10 @@ const SocketConnector = ({ channelId }: Props) => {
           setStore({ type: 'SET_LEAVE', payload: body.data });
           break;
         case 'PLAYLIST_ADD':
-          setStore({ type: 'SET_PLAYLIST', payload: JSON.parse(body.data) });
+          setStore({ type: 'ADD_PLAYLIST', payload: JSON.parse(body.data) });
+          break;
+        case 'PLAYLIST_MOVE':
+          setStore({ type: 'PLAYLIST_MOVE', payload: body.data });
           break;
         case 'PLAYLIST_REMOVE': {
           const data = body.data as MessageType['PLAYLIST_REMOVE'];
@@ -70,6 +73,9 @@ const SocketConnector = ({ channelId }: Props) => {
           setStore({ type: 'SET_VIDEO_TIME', payload: body.data });
           break;
         }
+        case 'VIDEO_PLAY':
+          setStore({ type: 'SET_VIDEO', payload: body.data });
+          break;
         default:
           break;
       }

--- a/src/app/channel/_components/playlist/index.tsx
+++ b/src/app/channel/_components/playlist/index.tsx
@@ -84,10 +84,12 @@ const Playlist = ({ channel, owner }: Props) => {
 
   return (
     <section
-      className={`flex w-full flex-col py-5 desktop:order-1 desktop:max-w-[384px] desktop:px-8 ${isFold && 'desktop:px-[22px]'}`}
+      className={`flex w-full flex-col desktop:order-1 desktop:max-h-screen desktop:max-w-[384px] desktop:px-8 ${isFold && 'desktop:px-[22px]'}`}
     >
       {/** 헤더 */}
-      <header className={`flex h-[67px] items-center justify-between shadow-xl `}>
+      <header
+        className={`flex h-[67px] shrink-0 items-center justify-between shadow-xl desktop:h-[90px]`}
+      >
         <div className="flex items-center">
           {/** 플레이리스트 펼치기 버튼 */}
           <button
@@ -120,7 +122,7 @@ const Playlist = ({ channel, owner }: Props) => {
             <ol
               {...provided.droppableProps}
               ref={provided.innerRef}
-              className={`overflow-y-auto no-scrollbar ${isFold ? 'hidden' : ''}`}
+              className={`h-[320px] overflow-y-auto no-scrollbar desktop:h-screen-playList ${isFold ? 'hidden' : ''}`}
             >
               {playlist?.map((item, index) => (
                 <Draggable
@@ -169,7 +171,9 @@ const Playlist = ({ channel, owner }: Props) => {
 
       {/** URL INPUT */}
       {isOwner && (
-        <div className={`mt-4 ${isFold ? 'hidden' : ''}`}>
+        <div
+          className={`pb-3 desktop:fixed desktop:bottom-0 desktop:w-[320px] ${isFold ? 'hidden' : ''}`}
+        >
           <Input
             value={url}
             onChange={(e) => {

--- a/src/app/channel/_components/playlist/index.tsx
+++ b/src/app/channel/_components/playlist/index.tsx
@@ -42,7 +42,7 @@ const Playlist = ({ channel, owner }: Props) => {
 
   useEffect(() => {
     const fetch = async () => {
-      const res = await getPlaylist({ channelId: channel_id, pageSize: 20 });
+      const res = await getPlaylist({ channelId: channel_id, pageSize: 50 });
       setStore({ type: 'ADD_PLAYLIST', payload: res.playlists });
     };
 
@@ -52,7 +52,11 @@ const Playlist = ({ channel, owner }: Props) => {
   /** 비디오 재생 */
   const handlePlay = (index: number) => {
     if (!isOwner) return;
-    send('VIDEO_PLAY', { playlist_no: playlist[index].playlist_no, playing: true });
+    send('VIDEO_PLAY', {
+      playlist_no: playlist[index].playlist_no,
+      url: playlist[index].url,
+      playing: true,
+    });
   };
 
   /** 비디오 삭제 */

--- a/src/app/channel/_components/playlist/index.tsx
+++ b/src/app/channel/_components/playlist/index.tsx
@@ -73,7 +73,6 @@ const Playlist = ({ channel, owner }: Props) => {
   };
 
   /** 드래그앤드랍 */
-  //! optimistic update 필요
   const onDragEnd = ({ source, destination }: DropResult) => {
     if (!isOwner || !destination) return;
 
@@ -85,10 +84,10 @@ const Playlist = ({ channel, owner }: Props) => {
 
   return (
     <section
-      className={`h-full py-5 desktop:order-1 desktop:px-8 ${isFold && 'desktop:px-[22px]'}`}
+      className={`flex w-full flex-col py-5 desktop:order-1 desktop:max-w-[384px] desktop:px-8 ${isFold && 'desktop:px-[22px]'}`}
     >
       {/** 헤더 */}
-      <header className={`flex h-[4.1875rem] items-center justify-between shadow-xl `}>
+      <header className={`flex h-[67px] items-center justify-between shadow-xl `}>
         <div className="flex items-center">
           {/** 플레이리스트 펼치기 버튼 */}
           <button
@@ -118,57 +117,59 @@ const Playlist = ({ channel, owner }: Props) => {
       <DragDropContext onDragEnd={onDragEnd}>
         <Droppable droppableId="playlist">
           {(provided) => (
-            <div {...provided.droppableProps} ref={provided.innerRef}>
-              <ol className={`flex flex-col ${isFold && 'hidden'}`}>
-                {playlist?.map((item, index) => (
-                  <Draggable
-                    key={item.playlist_no}
-                    draggableId={item.playlist_no.toString()}
-                    index={index}
-                    isDragDisabled={!isOwner}
-                  >
-                    {(provided) => (
-                      <li
-                        ref={provided.innerRef}
-                        {...provided.draggableProps}
-                        {...provided.dragHandleProps}
-                        onClick={(e) => {
-                          e.preventDefault();
-                          handlePlay(index);
-                        }}
-                        onMouseEnter={() => setHoveredItem(item.playlist_no)}
-                        onMouseLeave={() => setHoveredItem(null)}
-                        className={`relative h-[66px] rounded-lg border p-3 transition-colors desktop:w-[320px] ${isOwner && 'hover:border-main-skyblue hover:bg-main-skyblue/20'} ${playlist_no === item.playlist_no ? 'border-main-skyblue bg-main-skyblue/20' : 'border-transparent'}`}
-                      >
-                        <PlaylistCard {...item} />
-                        {isOwner && hoveredItem === item.playlist_no && (
-                          <div className="absolute right-2 top-1/2 flex -translate-y-1/2 gap-4">
-                            <Button
-                              size="icon"
-                              className="size-5 p-0 tablet:size-6"
-                              onClick={(e) => {
-                                e.preventDefault();
-                                handleDelete(item.playlist_no);
-                              }}
-                            >
-                              <Trash2 className="text-main-skyblue" />
-                            </Button>
-                          </div>
-                        )}
-                      </li>
-                    )}
-                  </Draggable>
-                ))}
-              </ol>
+            <ol
+              {...provided.droppableProps}
+              ref={provided.innerRef}
+              className={`overflow-y-auto no-scrollbar ${isFold ? 'hidden' : ''}`}
+            >
+              {playlist?.map((item, index) => (
+                <Draggable
+                  key={item.playlist_no}
+                  draggableId={item.playlist_no.toString()}
+                  index={index}
+                  isDragDisabled={!isOwner}
+                >
+                  {(provided) => (
+                    <li
+                      ref={provided.innerRef}
+                      {...provided.draggableProps}
+                      {...provided.dragHandleProps}
+                      onClick={(e) => {
+                        e.preventDefault();
+                        handlePlay(index);
+                      }}
+                      onMouseEnter={() => setHoveredItem(item.playlist_no)}
+                      onMouseLeave={() => setHoveredItem(null)}
+                      className={`relative h-[66px] rounded-lg border p-3 transition-colors desktop:w-[320px] ${isOwner && 'hover:border-main-skyblue hover:bg-main-skyblue/20'} ${playlist_no === item.playlist_no ? 'border-main-skyblue bg-main-skyblue/20' : 'border-transparent'}`}
+                    >
+                      <PlaylistCard {...item} />
+                      {isOwner && hoveredItem === item.playlist_no && (
+                        <div className="absolute right-2 top-1/2 flex -translate-y-1/2 gap-4">
+                          <Button
+                            size="icon"
+                            className="size-5 p-0 tablet:size-6"
+                            onClick={(e) => {
+                              e.preventDefault();
+                              handleDelete(item.playlist_no);
+                            }}
+                          >
+                            <Trash2 className="text-main-skyblue" />
+                          </Button>
+                        </div>
+                      )}
+                    </li>
+                  )}
+                </Draggable>
+              ))}
               {provided.placeholder}
-            </div>
+            </ol>
           )}
         </Droppable>
       </DragDropContext>
 
       {/** URL INPUT */}
       {isOwner && (
-        <div className={`${isFold && 'hidden'}`}>
+        <div className={`mt-4 ${isFold ? 'hidden' : ''}`}>
           <Input
             value={url}
             onChange={(e) => {

--- a/src/app/channel/_components/playlist/index.tsx
+++ b/src/app/channel/_components/playlist/index.tsx
@@ -84,16 +84,14 @@ const Playlist = ({ channel, owner }: Props) => {
 
   return (
     <section
-      className={`flex w-full flex-col desktop:order-1 desktop:max-h-screen desktop:max-w-[384px] desktop:px-8 ${isFold && 'desktop:px-[22px]'}`}
+      className={`flex flex-col desktop:order-1 desktop:max-h-screen desktop:max-w-[384px] desktop:px-8 ${isFold ? 'desktop:px-[22px]' : 'w-full'}`}
     >
       {/** 헤더 */}
-      <header
-        className={`flex h-[67px] shrink-0 items-center justify-between shadow-xl desktop:h-[90px]`}
-      >
+      <header className={`flex h-[67px] items-center justify-between shadow-xl desktop:h-[90px]`}>
         <div className="flex items-center">
           {/** 플레이리스트 펼치기 버튼 */}
           <button
-            className={`${isFold && 'rounded desktop:p-[10px] desktop:hover:bg-transparent-white-10'}`}
+            className={`${isFold ? 'rounded desktop:p-[10px] desktop:hover:bg-transparent-white-10' : ''}`}
             onClick={() => setIsFold(!isFold)}
             disabled={!isFold}
           >

--- a/src/app/channel/_components/playlist/index.tsx
+++ b/src/app/channel/_components/playlist/index.tsx
@@ -76,6 +76,14 @@ const Playlist = ({ channel, owner }: Props) => {
   const onDragEnd = ({ source, destination }: DropResult) => {
     if (!isOwner || !destination) return;
 
+    setStore({
+      type: 'PLAYLIST_MOVE',
+      payload: {
+        playlist_no: playlist[source.index].playlist_no,
+        sequence: destination.index,
+      },
+    });
+
     send('PLAYLIST_MOVE', {
       playlist_no: playlist[source.index].playlist_no,
       sequence: destination.index,

--- a/src/app/channel/_hooks/usePlaylist.ts
+++ b/src/app/channel/_hooks/usePlaylist.ts
@@ -1,30 +1,18 @@
+import send from '@/services/websocket/send';
 import { useSocketStore } from '@/stores/useSocketStore';
 
 const usePlaylist = () => {
-  const setStore = useSocketStore((state) => state.setSocketStore);
+  const next = () => {
+    const { playlist, video } = useSocketStore.getState();
 
-  const next = (cursor?: number) => {
-    const { playlist } = useSocketStore.getState();
+    let nextIndex = playlist.findIndex((item) => item.playlist_no === video.playlist_no) + 1;
+    if (playlist.length <= nextIndex) {
+      nextIndex = 0;
+    }
 
-    const calc = () => {
-      let newCursor = 0;
-      if (cursor) {
-        newCursor = cursor;
-      } else {
-        newCursor = playlist.cursor + 1;
-      }
+    const { playlist_no, url } = playlist[nextIndex];
 
-      if (playlist.length <= newCursor) newCursor = 0;
-
-      return newCursor;
-    };
-
-    const nextCursor = calc();
-
-    const { playlist_no, url } = playlist.data[nextCursor];
-
-    setStore({ type: 'SET_VIDEO', payload: { playlist_no, url } });
-    setStore({ type: 'SET_PLAYLIST_CURSOR', payload: nextCursor });
+    send('VIDEO_PLAY', { playlist_no, playing: true });
   };
 
   return { next };

--- a/src/app/channel/_hooks/usePlaylist.ts
+++ b/src/app/channel/_hooks/usePlaylist.ts
@@ -12,7 +12,7 @@ const usePlaylist = () => {
 
     const { playlist_no, url } = playlist[nextIndex];
 
-    send('VIDEO_PLAY', { playlist_no, playing: true });
+    send('VIDEO_PLAY', { playlist_no, url, playing: true });
   };
 
   return { next };

--- a/src/components/modal/ShareChannelModal.tsx
+++ b/src/components/modal/ShareChannelModal.tsx
@@ -13,7 +13,7 @@ import { DialogClose, DialogContent, DialogHeader, DialogTitle } from '../ui/dia
 const ShareChannelModal = () => {
   const params = useParams() as { channel_id: string };
   const { playlist, video } = useSocketStore((state) => ({
-    playlist: state.playlist.data,
+    playlist: state.playlist,
     video: state.video,
   }));
   const [channelTitle, setChannelTitle] = useState('');

--- a/src/services/websocket/type.ts
+++ b/src/services/websocket/type.ts
@@ -1,3 +1,4 @@
+import { ChannelPermission } from '../channel/type';
 import { Playlist } from '../playlist/type';
 
 /** 채팅 입력 */
@@ -27,6 +28,7 @@ export type UserLeaveReq = {
 /** 영상 재생/일시정지 */
 export type VideoPlayReq = {
   playlist_no: number;
+  url: string;
   playing: boolean;
 };
 
@@ -100,6 +102,7 @@ export type MessageType = {
   /** 비디오 재생 및 일시정지 */
   VIDEO_PLAY: {
     playlist_no: number;
+    url: string;
     playing: boolean;
   };
 
@@ -111,6 +114,15 @@ export type MessageType = {
 
   /** 재생시간 */
   VIDEO_TIME: number;
+
+  /** 채널 권한 변경 */
+  CHANNEL_PERMISSION_CHANGE: { channel_permissions: ChannelPermission };
+
+  /** 채널 유저역할 변경 */
+  CHANNEL_USER_ROLE_CHANGE: {
+    user_id: string;
+    role_id: string;
+  };
 };
 
 export interface MessageBody<T extends keyof MessageType = never> {

--- a/src/stores/useSocketStore.ts
+++ b/src/stores/useSocketStore.ts
@@ -120,11 +120,14 @@ export const useSocketStore = create<SocketStore>((set) => ({
       case 'PLAYLIST_MOVE':
         set((state) => {
           const { playlist_no, sequence } = action.payload;
-          const index = state.playlist.findIndex((video) => video.playlist_no === playlist_no);
-          if (index === -1) return state;
 
-          const items = state.playlist;
-          const [reorderedItem] = items.splice(index, 1);
+          const currentIndex = state.playlist.findIndex(
+            (video) => video.playlist_no === playlist_no,
+          );
+          if (currentIndex === -1) return state;
+
+          const items = Array.from(state.playlist);
+          const [reorderedItem] = items.splice(currentIndex, 1);
           items.splice(sequence, 0, reorderedItem);
 
           return {

--- a/src/stores/useSocketStore.ts
+++ b/src/stores/useSocketStore.ts
@@ -124,7 +124,7 @@ export const useSocketStore = create<SocketStore>((set) => ({
           const currentIndex = state.playlist.findIndex(
             (video) => video.playlist_no === playlist_no,
           );
-          if (currentIndex === -1) return state;
+          if (currentIndex === -1 || currentIndex === sequence) return state;
 
           const items = Array.from(state.playlist);
           const [reorderedItem] = items.splice(currentIndex, 1);

--- a/src/stores/useSocketStore.ts
+++ b/src/stores/useSocketStore.ts
@@ -4,13 +4,11 @@ import { SEVER_CHAT_MESSAGE, SEVER_NICKNAME, ServerChatForm } from '@/utils/cons
 import { create } from 'zustand';
 
 type VideoType = MessageType['VIDEO_PLAY'] & MessageType['VIDEO_MOVE'] & { url: string };
-type PlaylistType = { data: Playlist[]; cursor: number; length: number };
-
 interface SocketStore {
   chatting: MessageType['USER_CHAT'][];
   userJoin: MessageType['USER_JOIN'];
   userLeave: MessageType['USER_LEAVE'];
-  playlist: PlaylistType;
+  playlist: Playlist[];
   video: VideoType;
   viewer: MessageType['CHANNEL_VIEWER'];
   isConnected: boolean;
@@ -29,7 +27,7 @@ const initialData: Pick<
   chatting: [],
   userJoin: { user_id: '', nickname: '' },
   userLeave: { user_id: '', nickname: '' },
-  playlist: { data: [], cursor: 0, length: 0 },
+  playlist: [],
   viewer: { anonymous_users: 0, login_users: 0, total_users: 0 },
   video: { playlist_no: -1, playing: false, playtime: 0, url: '' },
   isConnected: false,
@@ -40,9 +38,11 @@ type Action =
   | { type: 'SET_CHATTING'; payload: MessageType['USER_CHAT'] }
   | { type: 'SET_JOIN'; payload: MessageType['USER_JOIN'] }
   | { type: 'SET_LEAVE'; payload: MessageType['USER_LEAVE'] }
-  | { type: 'SET_PLAYLIST'; payload: Playlist[] | Playlist }
+  | { type: 'ADD_PLAYLIST'; payload: Playlist[] | Playlist }
   | { type: 'SET_PLAYLIST_CURSOR'; payload: number }
   | { type: 'PLAYLIST_REMOVE'; payload: number }
+  | { type: 'SET_PLAYLIST'; payload: Playlist[] }
+  | { type: 'PLAYLIST_MOVE'; payload: MessageType['PLAYLIST_MOVE'] }
   | { type: 'SET_VIDEO'; payload: Partial<VideoType> }
   | { type: 'SET_VIDEO_TIME'; payload: number }
   | { type: 'SET_CONNECTED'; payload: boolean }
@@ -95,51 +95,46 @@ export const useSocketStore = create<SocketStore>((set) => ({
         }));
         break;
 
-      case 'SET_PLAYLIST':
+      case 'ADD_PLAYLIST':
         if (Array.isArray(action.payload)) {
           const payload = action.payload;
-          set((state) => ({
-            playlist: { data: payload, cursor: state.playlist.cursor, length: payload.length },
-          }));
+          set((state) => ({ playlist: [...state.playlist, ...payload] }));
         } else {
           const { ...rest } = action.payload;
           set((state) => ({
-            playlist: {
-              data: [...state.playlist.data, rest],
-              cursor: state.playlist.cursor,
-              length: state.playlist.length + 1,
-            },
+            playlist: [...state.playlist, rest],
           }));
         }
         break;
 
-      case 'SET_PLAYLIST_CURSOR':
-        set((state) => ({
-          playlist: {
-            data: state.playlist.data,
-            cursor: action.payload,
-            length: state.playlist.length,
-          },
-        }));
-        break;
-
       case 'PLAYLIST_REMOVE':
         set((state) => {
-          const newPlaylistData = state.playlist.data.filter(
+          const newPlaylistData = state.playlist.filter(
             (video) => video.playlist_no !== action.payload,
           );
-          const newCursor =
-            state.playlist.cursor >= state.playlist.data.length - 1
-              ? state.playlist.data.length - 2
-              : state.playlist.cursor;
+
+          return { playlist: newPlaylistData };
+        });
+        break;
+
+      case 'PLAYLIST_MOVE':
+        set((state) => {
+          const { playlist_no, sequence } = action.payload;
+          const index = state.playlist.findIndex((video) => video.playlist_no === playlist_no);
+          if (index === -1) return state;
+
+          const items = state.playlist;
+          const [reorderedItem] = items.splice(index, 1);
+          items.splice(sequence, 0, reorderedItem);
+
           return {
-            playlist: {
-              data: newPlaylistData,
-              cursor: newCursor < 0 ? 0 : newCursor,
-              length: newPlaylistData.length,
-            },
+            playlist: items,
           };
         });
+        break;
+
+      case 'SET_PLAYLIST':
+        set({ playlist: action.payload });
         break;
 
       case 'SET_VIDEO': {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -61,6 +61,7 @@ const config = {
       borderWidth: { '1': '1px' },
       height: {
         'screen-chatList': 'calc(100vh-238px)',
+        'screen-playList': 'calc(100vh - 256px)',
       },
       backgroundColor: {
         'transparent-white-10': 'rgba(255, 255, 255, 0.1)',


### PR DESCRIPTION
## 관련 이슈
#104 
<!-- 관련된 이슈를 여기에 링크해 주세요: -->
<br/>

## 변경 유형

- [X] `feat` 새로운 기능
- [X] `refactor` 코드 리팩토링
- [ ] `fix` 버그 수정
- [X] `design` 사용자 UI 디자인 변경
- [ ] `comment` 주석 추가 및 변경
- [ ] `test` 테스트 코드 추가
- [ ] `docs` 문서 업데이트
- [ ] `style` 코드 포맷팅
- [ ] `chore` 빌드, 패키지 매니저, 설정 파일 변경
- [ ] `rename` 파일/폴더명 수정
- [ ] `remove` 파일 삭제

## 변경사항 요약
- 플레이리스트 순서 변경 로직 수정
  - usePlaylist next() 수정
- 플레이리스트의 영상 클릭 시 바로 재생되도록 수정
- 채널 권한변경 응답 타입 추가
- 플레이리스트 레이아웃 수정
  <!-- 변경 사항에 대한 요약을 작성해주세요. -->

  <br/>

## 변경 내용
- 플레이리스트 순서 변경 시 다른 사용자에게도 적용되도록 수정
  - 기존의 경우 setStore로만 순서 변경을 반영함, 다른 사용자에게는 순서 변경이 반영되지 않음
  - 웹소캣 메시지 기반으로 순서를 변경하도록 수정
<!-- 변경 사항을 설명해 주세요. -->
<br/>

## 추가 정보
- next() 함수가 usePlaylist에서 커스텀 훅으로 제공될 필요가 없어보임
<!-- 필요 시 전달 사항, 참고 자료 등을 추가해주세요. -->
<br/>
