### PR TITLE
Feat: /channel/:channelId의 채널유저 모달 구현(내보내기 제외)

### DIFF
--- a/src/app/channel/_components/chatting/ChannelUsersModal.tsx
+++ b/src/app/channel/_components/chatting/ChannelUsersModal.tsx
@@ -2,12 +2,16 @@ import { useEffect, useState, useRef, useCallback } from 'react';
 
 import { getChannelUsers, getSearchChannelUser } from '@/services/channel';
 import { ChannelUserType } from '@/services/channel/type';
+import { usePermissionStore } from '@/stores/usePermissionStore';
+import { useUserStore } from '@/stores/User';
 import { PLACEHOLDER } from '@/utils/constants';
 import Image from 'next/image';
 import { createPortal } from 'react-dom';
 import { useInView } from 'react-intersection-observer';
+import { useShallow } from 'zustand/react/shallow';
 
-import SearchBar from '../SearchBar';
+import UserSettingModal from './UserSettingModal';
+import SearchBar from '../../../../components/SearchBar';
 
 interface ChannelUsersModalProps {
   channelId: string;
@@ -21,10 +25,19 @@ export default function ChannelUsersModal({ channelId, onClose }: ChannelUsersMo
   const [userList, setUserList] = useState<ChannelUserType[]>([]);
   const [totalCount, setTotalCount] = useState<number>(0);
   const [cursor, setCursor] = useState<number>(1);
+  const [openUserId, setOpenUserId] = useState<string | null>(null);
 
   const [ref, inView] = useInView();
   const usersRef = useRef<HTMLDivElement>(null);
   const noNextUser = userList.length >= totalCount;
+
+  const { roleId, permission } = usePermissionStore(
+    useShallow((state) => ({ roleId: state.roleId, permission: state.permission })),
+  );
+
+  const { user_id } = useUserStore((state) => ({
+    user_id: state.user_id,
+  }));
 
   const handleClose = (e: React.MouseEvent<HTMLDivElement>) => {
     if (e.target === e.currentTarget) {
@@ -87,7 +100,12 @@ export default function ChannelUsersModal({ channelId, onClose }: ChannelUsersMo
         onClick={handleClose}
         className="fixed inset-0 z-40 flex size-full items-center justify-center bg-overlay"
       >
-        <section className="relative flex h-[554px] w-[335px] flex-col items-center justify-center gap-7 rounded-lg border-1 border-neutral-400 bg-gradient-to-bottom px-5 pb-5 pt-[40px] shadow-2xl backdrop-blur-[32] tablet:h-[640px] tablet:w-[500px] tablet:px-[40px]">
+        <section
+          className="relative flex h-[554px] w-[335px] flex-col items-center justify-center gap-7 rounded-lg border-1 border-neutral-400 bg-gradient-to-bottom px-5 pb-5 pt-[40px] shadow-2xl backdrop-blur-[32] tablet:h-[640px] tablet:w-[500px] tablet:px-[40px]"
+          onClick={() => {
+            if (openUserId) setOpenUserId(null);
+          }}
+        >
           <h2 className="text-center large-bold tablet:max-bold">채널 유저</h2>
           <div className="flex items-center gap-1 small-regular tablet:base-regular">
             <div className="relative size-[22px] tablet:size-[24px]">
@@ -115,31 +133,51 @@ export default function ChannelUsersModal({ channelId, onClose }: ChannelUsersMo
             ref={usersRef}
             className="flex h-[322px] w-full flex-col gap-5 overflow-auto tablet:h-[348px]"
           >
-            {userList.map((user) => (
-              <div
-                key={user.user_id}
-                className="flex h-9 items-center justify-between gap-2.5 tablet:h-[40px]"
-              >
-                <div className="relative size-9 overflow-hidden rounded-full tablet:size-[40px]">
-                  <Image
-                    fill
-                    src={user.profile_image || '/default-profile-image.png'}
-                    alt="유저 프로필 이미지"
-                  />
-                </div>
-                <span
-                  className="grow small-bold tablet:base-bold"
-                  style={{ color: user.profile_color || '#00FFFF' }}
+            {userList.map((user) => {
+              const isModalOpen = roleId === 'C0000' || permission.ban || user_id === user.user_id;
+
+              return (
+                <div
+                  key={user.user_id}
+                  className="flex h-9 items-center justify-between gap-2.5 tablet:h-[40px]"
                 >
-                  {user.nickname}
-                </span>
-                <div className="flex size-8 items-center justify-center rounded-md hover:bg-neutral-500 tablet:size-9">
-                  <div className="relative size-5 tablet:size-6">
-                    <Image fill src="/kebab-menu.svg" alt={`${user.nickname}의 메뉴 버튼`} />
+                  <div className="relative size-9 overflow-hidden rounded-full tablet:size-[40px]">
+                    <Image
+                      fill
+                      src={user.profile_image || '/default-profile-image.png'}
+                      alt="유저 프로필 이미지"
+                    />
                   </div>
+                  <span
+                    className="grow small-bold tablet:base-bold"
+                    style={{ color: user.profile_color || '#00FFFF' }}
+                  >
+                    {user.nickname}
+                  </span>
+                  {isModalOpen && (
+                    <div className="flex size-8 cursor-pointer items-center justify-center rounded-md hover:bg-neutral-500 tablet:size-9">
+                      <div className="relative size-5 tablet:size-6">
+                        <Image
+                          fill
+                          src="/kebab-menu.svg"
+                          alt={`${user.nickname}의 메뉴 버튼`}
+                          sizes="30vw"
+                          onClick={() => setOpenUserId(user.user_id)}
+                        />
+                        {openUserId === user.user_id && (
+                          <UserSettingModal
+                            userId={user.user_id}
+                            userRole={user.role_id}
+                            channelId={channelId}
+                            onClose={onClose}
+                          />
+                        )}
+                      </div>
+                    </div>
+                  )}
                 </div>
-              </div>
-            ))}
+              );
+            })}
             {!noNextUser && <div ref={ref} onClick={() => handleFetchUsers()} />}
           </section>
           <div

--- a/src/app/channel/_components/chatting/ChatHeader.tsx
+++ b/src/app/channel/_components/chatting/ChatHeader.tsx
@@ -1,7 +1,8 @@
 import { useState } from 'react';
 
-import ChannelUsersModal from '@/components/modal/ChannelUsersModal';
+import ChannelUsersModal from '@/app/channel/_components/chatting/ChannelUsersModal';
 import Tooltip from '@/components/Tooltip';
+import { useUserStore } from '@/stores/User';
 import { useSocketStore } from '@/stores/useSocketStore';
 import Image from 'next/image';
 
@@ -16,6 +17,10 @@ export default function ChatHeader({ isFold, setIsFold, channelId }: ChatHeaderP
   const [showChannelUsersModal, setShowChannelUsersModal] = useState(false);
 
   const viewer = useSocketStore((state) => state.viewer);
+
+  const { nickname } = useUserStore((state) => ({
+    nickname: state.nickname,
+  }));
 
   return (
     <>
@@ -41,8 +46,9 @@ export default function ChatHeader({ isFold, setIsFold, channelId }: ChatHeaderP
           >
             채팅
           </h2>
-          <div
-            className={`-mt-0.5 flex cursor-pointer items-center gap-1 rounded-md px-2 py-0.5 text-neutral-200 ${isFold && 'desktop:hidden'}`}
+          <button
+            className={`-mt-0.5 flex items-center gap-1 rounded-md px-2 py-0.5 text-neutral-200 ${isFold && 'desktop:hidden'} ${nickname ? 'cursor-pointer' : ''}`}
+            disabled={!nickname}
             onClick={() => setShowChannelUsersModal(true)}
           >
             <Image
@@ -53,7 +59,7 @@ export default function ChatHeader({ isFold, setIsFold, channelId }: ChatHeaderP
               height={16}
             />
             <p className="small-regular">{viewer.login_users}</p>
-          </div>
+          </button>
         </div>
         {!isFold && (
           <button

--- a/src/app/channel/_components/chatting/UserSettingModal.tsx
+++ b/src/app/channel/_components/chatting/UserSettingModal.tsx
@@ -1,0 +1,80 @@
+import { patchChannelRole } from '@/services/channel';
+import { RoleIdType } from '@/services/channel/type';
+import { usePermissionStore } from '@/stores/usePermissionStore';
+import { useUserStore } from '@/stores/User';
+import Link from 'next/link';
+import { useShallow } from 'zustand/react/shallow';
+
+interface UserSettingModalProps {
+  userId: string;
+  userRole: string;
+  channelId: string;
+  onClose: () => void;
+}
+
+export default function UserSettingModal({
+  userId,
+  userRole,
+  channelId,
+  onClose,
+}: UserSettingModalProps) {
+  const { roleId, permission } = usePermissionStore(
+    useShallow((state) => ({ roleId: state.roleId, permission: state.permission })),
+  );
+
+  const { user_id } = useUserStore((state) => ({
+    user_id: state.user_id,
+  }));
+
+  const isMe = userId === user_id;
+
+  const handleChangeRole = async (newRoleId: string) => {
+    const params = {
+      role_id: newRoleId as RoleIdType,
+      user_id: userId,
+    };
+    try {
+      if (roleId) {
+        const res = await patchChannelRole(channelId, params);
+        alert(newRoleId === 'C0100' ? '관리자로 지정되었어요.' : '관리자가 취소되었어요.');
+        onClose();
+      }
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  return (
+    <div className="absolute -right-1 -top-2 z-50 flex w-[160px] flex-col rounded-[8px] border border-neutral-400 bg-neutral-600 py-[10px]">
+      {roleId === 'C0000' && userRole === 'C0100' && !isMe && (
+        <button
+          onClick={() => handleChangeRole('C0200')}
+          className="flex w-full items-center justify-center py-[13px] text-neutral-100 base-regular hover:bg-neutral-500"
+        >
+          관리자 취소하기
+        </button>
+      )}
+      {roleId === 'C0000' && userRole === 'C0200' && !isMe && (
+        <button
+          onClick={() => handleChangeRole('C0100')}
+          className="flex w-full items-center justify-center py-[13px] text-neutral-100 base-regular hover:bg-neutral-500"
+        >
+          관리자 지정하기
+        </button>
+      )}
+      {permission.ban && !isMe && (
+        <button className="flex items-center justify-center py-[13px] text-neutral-100 base-regular hover:bg-neutral-500">
+          내보내기
+        </button>
+      )}
+      {isMe && (
+        <Link
+          href="/mypage"
+          className="flex items-center justify-center py-[13px] text-neutral-100 base-regular hover:bg-neutral-500"
+        >
+          내 정보 변경하기
+        </Link>
+      )}
+    </div>
+  );
+}

--- a/src/services/channel/index.ts
+++ b/src/services/channel/index.ts
@@ -11,6 +11,7 @@ import {
   GetChannelSearchResponse,
   GetChannelUsersResponse,
   GetSearchChannelUserResponse,
+  RoleIdType,
 } from './type';
 import revalidate from '../revalidate';
 
@@ -97,6 +98,7 @@ export const getChannelUsers = async (channelId: string, cursor: number = 1) => 
       headers: {
         Authorization: `Bearer ${session?.user.accessToken}`,
       },
+      next: { tags: ['channelUsers'] },
     },
   );
 
@@ -124,5 +126,20 @@ export const deleteChannel = async (channelId: string) => {
     },
   });
   await revalidate('channel');
+  return data;
+};
+
+/** 채널 사용자 권한 수정 */
+export const patchChannelRole = async (
+  channelId: string,
+  params: { role_id: RoleIdType; user_id: string },
+) => {
+  const session = await getSession();
+  const data = await fetcher.patch(`${DOMAIN.CHANNEL}/${channelId}/role`, params, {
+    headers: {
+      Authorization: `Bearer ${session?.user.accessToken}`,
+    },
+  });
+  await revalidate('channelUsers');
   return data;
 };


### PR DESCRIPTION
## 관련 이슈

#116 
<!-- 관련된 이슈를 여기에 링크해 주세요: -->
<br/>

## 변경 유형

- [x] `feat` 새로운 기능
- [ ] `refactor` 코드 리팩토링
- [ ] `fix` 버그 수정
- [ ] `design` 사용자 UI 디자인 변경
- [ ] `comment` 주석 추가 및 변경
- [ ] `test` 테스트 코드 추가
- [ ] `docs` 문서 업데이트
- [ ] `style` 코드 포맷팅
- [ ] `chore` 빌드, 패키지 매니저, 설정 파일 변경
- [ ] `rename` 파일/폴더명 수정
- [ ] `remove` 파일 삭제

## 변경사항 요약

- [x] /channel/:channelId 페이지에서 채팅의 유저 수 클릭하면 '채널 유저' 모달창 보이게 구현
- [x] 채널에 접속한 유저를 선택해서 '관리자 지정하기, 관리자 취소하기, 내정보변경하기' 기능 구현
  <!-- 변경 사항에 대한 요약을 작성해주세요. -->

  <br/>

## 추가 정보

- 내보내기 기능 구현 못함. api 필요.
<!-- 필요 시 전달 사항, 참고 자료 등을 추가해주세요. -->
<br/>


![유저설정](https://github.com/user-attachments/assets/a8f1cf11-8b8f-477a-bb9c-b519ea86f6ee)

